### PR TITLE
Vector reward

### DIFF
--- a/highway_env/envs/common/abstract.py
+++ b/highway_env/envs/common/abstract.py
@@ -438,6 +438,12 @@ class MOAbstractEnv(AbstractEnv):
         """
         return self.reward
 
+    def registered(self) -> list:
+        """
+        Return the list of registered reward keys
+        """
+        return list(self.reward_callbacks.keys())
+
 class MultiAgentWrapper(Wrapper):
     def step(self, action):
         obs, reward, done, info = super().step(action)

--- a/highway_env/envs/common/abstract.py
+++ b/highway_env/envs/common/abstract.py
@@ -440,7 +440,7 @@ class MOAbstractEnv(AbstractEnv):
 
     def registered(self) -> list:
         """
-        Return the list of registered reward keys
+        :return: the list of registered reward keys
         """
         return list(self.reward_callbacks.keys())
 

--- a/highway_env/envs/mo_highway_env.py
+++ b/highway_env/envs/mo_highway_env.py
@@ -89,47 +89,37 @@ class MOHighwayEnv(AbstractEnv):
         """
         if not self.vehicle.on_road: return 0
         
-        reward = 0
-        if self.config["cur_reward"] == 0:
-            # SPEED
-            # Use forward speed rather than speed, see https://github.com/eleurent/highway-env/issues/268
-            forward_speed = self.vehicle.speed * np.cos(self.vehicle.heading)
-            reward = utils.lmap(forward_speed, self.config["reward_speed_range"], [0, 1])
+        reward = []
 
-        elif self.config["cur_reward"] == 1:
-            # RIGHT LANE
-            lanes = self.road.network.all_side_lanes(self.vehicle.lane_index)
-            lane = self.vehicle.target_lane_index[2] if isinstance(self.vehicle, ControlledVehicle) \
-                else self.vehicle.lane_index[2]
-            reward = lane / max(len(lanes) - 1, 1)
-            
-        elif self.config["cur_reward"] == 2:
-            # DON'T CRASH
-            reward = 0 if self.vehicle.crashed \
-                else 1
+        # SPEED
+        # Use forward speed rather than speed, see https://github.com/eleurent/highway-env/issues/268
+        forward_speed = self.vehicle.speed * np.cos(self.vehicle.heading)
+        reward.append(utils.lmap(forward_speed, self.config["reward_speed_range"], [0, 1]))
 
-        elif self.config["cur_reward"] == 3:
-            # MINIMIZE ACCELERATION (fuel efficiency?)
-            acc_max = self.vehicle.ACC_MAX
-            front_vehicle, rear_vehicle = self.vehicle.road.neighbour_vehicles(self.vehicle, self.vehicle.target_lane_index)
-            acc = self.vehicle.acceleration(ego_vehicle=self.vehicle, front_vehicle=front_vehicle, rear_vehicle=rear_vehicle)
-            norm_accel = utils.lmap(acc, [0,acc_max], [0,1])
-            reward = 1-norm_accel
+        # RIGHT LANE
+        lanes = self.road.network.all_side_lanes(self.vehicle.lane_index)
+        lane = self.vehicle.target_lane_index[2] if isinstance(self.vehicle, ControlledVehicle) \
+            else self.vehicle.lane_index[2]
+        reward.append(lane / max(len(lanes) - 1, 1))
             
-        elif self.config["cur_reward"] == 4:
-            # MAXIMIZE MIN DISTANCE
-            reward = np.min(
-                    [   
-                        np.linalg.norm(v.position - self.vehicle.position) 
-                        for v in self.road.vehicles 
-                        if v is not self.vehicle
-                    ]
-                )
-            
-        else:
-            # REQUESTED REWARD IS NOT DEFINED
-            print('No reward function defined for requested reward num', self.config["cur_reward"])
-            raise NotImplementedError
+        # DON'T CRASH
+        reward.append(0) if self.vehicle.crashed else reward.append(1)
+
+        # MINIMIZE ACCELERATION (fuel efficiency?)
+        acc_max = self.vehicle.ACC_MAX
+        front_vehicle, rear_vehicle = self.vehicle.road.neighbour_vehicles(self.vehicle, self.vehicle.target_lane_index)
+        acc = self.vehicle.acceleration(ego_vehicle=self.vehicle, front_vehicle=front_vehicle, rear_vehicle=rear_vehicle)
+        norm_accel = utils.lmap(acc, [0,acc_max], [0,1])
+        reward.append(1-norm_accel)
+        
+        # MAXIMIZE MIN DISTANCE
+        reward.append(np.min(
+                [   
+                    np.linalg.norm(v.position - self.vehicle.position) 
+                    for v in self.road.vehicles 
+                    if v is not self.vehicle
+                ]
+            ))
 
         return reward
 

--- a/highway_env/envs/mo_highway_env.py
+++ b/highway_env/envs/mo_highway_env.py
@@ -4,7 +4,7 @@ from typing import Tuple
 from gym.envs.registration import register
 
 from highway_env import utils
-from highway_env.envs.common.abstract import AbstractEnv, MOAbstractEnv
+from highway_env.envs.common.abstract import MOAbstractEnv
 from highway_env.envs.common.action import Action
 from highway_env.road.road import Road, RoadNetwork
 from highway_env.vehicle.controller import ControlledVehicle
@@ -77,14 +77,14 @@ class MOHighwayEnv(MOAbstractEnv):
     def _add_vehicle_front(self) -> None:
         """Add vehicle in front of leading car"""
         other_vehicles_type = utils.class_from_path(self.config["other_vehicles_type"])
-        vehicle = other_vehicles_type.create_random(self.road, spacing=1 / self.config["vehicles_density"])
+        vehicle = other_vehicles_type.create_random(self.road, spacing=1 / self.config["vehicles_density"], front=True)
         vehicle.randomize_behavior()
         self.road.vehicles.append(vehicle)
 
     def _add_vehicle_behind(self) -> None:
         """Add vehicle behind last car"""
         other_vehicles_type = utils.class_from_path(self.config["other_vehicles_type"])
-        vehicle = other_vehicles_type.create_random_behind(self.road, spacing=1 / self.config["vehicles_density"])
+        vehicle = other_vehicles_type.create_random(self.road, spacing=1 / self.config["vehicles_density"], front=False)
         vehicle.randomize_behavior()
         self.road.vehicles.append(vehicle)
 

--- a/highway_env/vehicle/kinematics.py
+++ b/highway_env/vehicle/kinematics.py
@@ -51,13 +51,14 @@ class Vehicle(RoadObject):
                       lane_from: Optional[str] = None,
                       lane_to: Optional[str] = None,
                       lane_id: Optional[int] = None,
-                      spacing: float = 1) \
+                      spacing: float = 1,
+                      front: bool = True) \
             -> "Vehicle":
         """
         Create a random vehicle on the road.
 
-        The lane and /or speed are chosen randomly, while longitudinal position is chosen in front of the leading
-        vehicle in the road with density based on the number of lanes.
+        The lane and/or speed are chosen randomly, while longitudinal position is chosen in front of the leading
+        vehicle or behind the last vehicle in the road with density based on the number of lanes.
 
         :param road: the road where the vehicle is driving
         :param speed: initial speed in [m/s]. If None, will be chosen randomly
@@ -65,6 +66,7 @@ class Vehicle(RoadObject):
         :param lane_to: end node of the lane to spawn in
         :param lane_id: id of the lane to spawn in
         :param spacing: ratio of spacing to the front vehicle, 1 being the default
+        :param: front: True to create in front of leading vehicle, False to create behind last vehicle
         :return: A vehicle with random position and/or speed
         """
         _from = lane_from or road.np_random.choice(list(road.network.graph.keys()))
@@ -78,48 +80,14 @@ class Vehicle(RoadObject):
                 speed = road.np_random.uniform(Vehicle.DEFAULT_INITIAL_SPEEDS[0], Vehicle.DEFAULT_INITIAL_SPEEDS[1])
         default_spacing = 12+1.0*speed
         offset = spacing * default_spacing * np.exp(-5 / 40 * len(road.network.graph[_from][_to]))
-        x0 = np.max([lane.local_coordinates(v.position)[0] for v in road.vehicles]) \
-            if len(road.vehicles) else 3*offset
-        x0 += offset * road.np_random.uniform(0.9, 1.1)
-        v = cls(road, lane.position(x0, 0), lane.heading_at(x0), speed)
-        return v
-
-    @classmethod
-    def create_random_behind(cls, road: Road,
-                      speed: float = None,
-                      lane_from: Optional[str] = None,
-                      lane_to: Optional[str] = None,
-                      lane_id: Optional[int] = None,
-                      spacing: float = 1) \
-            -> "Vehicle":
-        """
-        Create a random vehicle on the road.
-
-        The lane and /or speed are chosen randomly, while longitudinal position is chosen behind the last
-        vehicle in the road with density based on the number of lanes.
-
-        :param road: the road where the vehicle is driving
-        :param speed: initial speed in [m/s]. If None, will be chosen randomly
-        :param lane_from: start node of the lane to spawn in
-        :param lane_to: end node of the lane to spawn in
-        :param lane_id: id of the lane to spawn in
-        :param spacing: ratio of spacing to the front vehicle, 1 being the default
-        :return: A vehicle with random position and/or speed
-        """
-        _from = lane_from or road.np_random.choice(list(road.network.graph.keys()))
-        _to = lane_to or road.np_random.choice(list(road.network.graph[_from].keys()))
-        _id = lane_id if lane_id is not None else road.np_random.choice(len(road.network.graph[_from][_to]))
-        lane = road.network.get_lane((_from, _to, _id))
-        if speed is None:
-            if lane.speed_limit is not None:
-                speed = road.np_random.uniform(0.7*lane.speed_limit, 0.8*lane.speed_limit)
-            else:
-                speed = road.np_random.uniform(Vehicle.DEFAULT_INITIAL_SPEEDS[0], Vehicle.DEFAULT_INITIAL_SPEEDS[1])
-        default_spacing = 12+1.0*speed
-        offset = spacing * default_spacing * np.exp(-5 / 40 * len(road.network.graph[_from][_to]))
-        x0 = np.min([lane.local_coordinates(v.position)[0] for v in road.vehicles]) \
-            if len(road.vehicles) else 3*offset
-        x0 -= offset * road.np_random.uniform(0.9, 1.1)
+        if front:
+            x0 = np.max([lane.local_coordinates(v.position)[0] for v in road.vehicles]) \
+                if len(road.vehicles) else 3*offset
+            x0 += offset * road.np_random.uniform(0.9, 1.1)
+        else:
+            x0 = np.min([lane.local_coordinates(v.position)[0] for v in road.vehicles]) \
+                if len(road.vehicles) else 3*offset
+            x0 -= offset * road.np_random.uniform(0.9, 1.1)
         v = cls(road, lane.position(x0, 0), lane.heading_at(x0), speed)
         return v
 


### PR DESCRIPTION
Finished revising vector reward code, made MOAbstractEnv so that we can define custom reward callbacks in inheriting environments. Reward vector is now passed back in info(), and reward() returns a single reward from the vector specified by env.config(["cur_reward"])